### PR TITLE
feat: add support for `compilerOptions.moduleDetection`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,7 @@ pub struct CompilerOptions {
     pub jsx: Option<Jsx>,
     pub lib: Option<Vec<Lib>>,
     pub module: Option<Module>,
+    pub module_detection: Option<ModuleDetectionMode>,
     pub no_emit: Option<bool>,
     pub out_dir: Option<String>,
     pub out_file: Option<String>,
@@ -451,6 +452,22 @@ pub struct CompilerOptions {
     pub fallback_polling: Option<String>,
     pub watch_directory: Option<String>,
     pub watch_file: Option<String>,
+}
+
+/// Module detection mode
+///
+/// This setting controls how TypeScript determines whether a file is a script or a module.
+/// These choices include:
+///   - "auto" (default) - TypeScript will not only look for import and export statements, but it will also check whether the "type" field in a package.json is set to "module" when running with module: nodenext or node16, and check whether the current file is a JSX file when running under jsx: react-jsx.
+///   - "legacy" - The same behavior as 4.6 and prior, usings import and export statements to determine whether a file is a module.
+///   - "force" - Ensures that every non-declaration file is treated as a module.
+#[derive(Deserialize, Debug, PartialEq, Copy, Clone, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ModuleDetectionMode {
+	#[default]
+	Auto,
+	Legacy,
+	Force,
 }
 
 /// Module resolution mode

--- a/test/tsconfig.complete.json
+++ b/test/tsconfig.complete.json
@@ -82,6 +82,7 @@
     "removeComments": false, // Remove all comments except copy-right header comments beginning with //!
     "experimentalDecorators": true, // Enables experimental support for ES7 decorators.
     "emitDecoratorMetadata": true, // Enables experimental support for emitting type metadata for decorators.
+    "moduleDetection": "auto", // Controls how TypeScript determines whether a file is a script or a module.
 
     // Source map options
     "sourceMap": false, // Generates corresponding '.map' file.


### PR DESCRIPTION
Introduced in TypeScript 4.7:
- https://www.typescriptlang.org/tsconfig/#moduleDetection
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#control-over-module-detection

Thanks for the library!